### PR TITLE
Needed local variables initialization in order not to crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,6 +142,9 @@ saver = tf.train.Saver(max_to_keep = 5)
 sess = tf.Session()
 sess.run([init_op])
 
+# Init local variables
+sess.run(tf.local_variables_initializer())
+
 # if model exist, restore
 """
 #if model exist :


### PR DESCRIPTION
Every time I tried to run the net on GPU, I encountered errors regarding variable "matching_names", which was said to not be initialized. I found that using tf.local_variables_initializer() fixes the problem.